### PR TITLE
Add stress test run to zuul

### DIFF
--- a/.clouds.yml
+++ b/.clouds.yml
@@ -1,0 +1,16 @@
+---
+# NOTE: This is the clouds.yml file for the stress tests run by Zuul.
+
+clouds:
+  openstack:
+    auth:
+      auth_url: http://localhost/identity
+      username: admin
+      password: password
+      project_name: admin
+      project_domain_name: Default
+      user_domain_name: Default
+    region: RegionOne
+    block_storage_api_version: 3
+    identity_api_version: 3
+    interface: public

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,4 +1,13 @@
 ---
+- job:
+    name: openstack-simple-stress-test
+    pre-run: playbooks/pre-test.yml
+    run: playbooks/test.yml
+    timeout: 14400
+    roles:
+      - zuul: osism/zuul-jobs
+        name: devstack
+
 - project:
     merge-mode: squash-merge
     default-branch: main
@@ -6,6 +15,7 @@
       jobs:
         - flake8
         - mypy
+        - openstack-simple-stress-test
         - python-black
         - tox:
             vars:
@@ -15,6 +25,7 @@
       jobs:
         - flake8
         - mypy
+        - openstack-simple-stress-test
         - python-black
         - tox:
             vars:
@@ -24,6 +35,7 @@
       jobs:
         - flake8
         - mypy
+        - openstack-simple-stress-test
         - python-black
         - tox:
             vars:

--- a/playbooks/pre-test.yml
+++ b/playbooks/pre-test.yml
@@ -1,0 +1,62 @@
+---
+- name: Pre integration test play
+  hosts: all
+
+  vars:
+    zuul_work_dir: "{{ zuul.project.src_dir }}"
+
+  roles:
+    - role: ensure-tox
+    - role: devstack
+      vars:
+        # yamllint disable-line rule:line-length
+        devstack_services: "keystone nova n-api n-cpu n-cond n-sch n-novnc n-api-meta rabbit placement-api placement-client g-api ovn-controller ovn-northd ovs-vswitchd ovsdb-server q-svc q-ovn-metadata-agent"
+        devstack_use_fake_driver: true
+
+  tasks:
+    - name: Copy clouds.yml configuration file
+      ansible.builtin.copy:
+        src: "{{ zuul_work_dir }}/.clouds.yml"
+        dest: "{{ zuul_work_dir }}/clouds.yml"
+        remote_src: true
+        mode: '0644'
+        owner: zuul
+        group: zuul
+
+    - name: Print openstack CLI version
+      ansible.builtin.command: openstack --version
+      failed_when: false
+
+    - name: Create expected flavor
+      # yamllint disable-line rule:line-length
+      ansible.builtin.command: openstack --os-cloud openstack flavor create SCS-1V-1-10 --id SCS-1V-1-10 --ram 1024 --disk 10 --vcpus 1
+      args:
+        chdir: "{{ zuul_work_dir }}"
+
+    - name: Find image file
+      ansible.builtin.find:
+        paths: "{{ zuul_work_dir }}/devstack/files/"
+        file_type: file
+        patterns: "*.img"
+        recurse: false
+      register: find_image
+      # yamllint disable-line rule:line-length
+      failed_when: (find_image is not defined) or (find_image.files | length == 0)
+
+    - name: Create expected image
+      # yamllint disable-line rule:line-length
+      ansible.builtin.command: openstack --os-cloud openstack image create "cirros" --file ./devstack/files/{{ find_image.files[0].path | basename }} --disk-format qcow2 --container-format bare --public
+      args:
+        chdir: "{{ zuul_work_dir }}"
+
+    - name: Create expected network
+      # yamllint disable-line rule:line-length
+      ansible.builtin.command: "openstack --os-cloud openstack network create simple-stress"
+      args:
+        chdir: "{{ zuul_work_dir }}"
+
+    - name: Create expected subnet
+      # yamllint disable-line rule:line-length
+      ansible.builtin.command: "openstack --os-cloud openstack subnet create simple-stress-subnet --network simple-stress --subnet-range 10.100.1.0/24"
+      args:
+        chdir: "{{ zuul_work_dir }}"

--- a/playbooks/test.yml
+++ b/playbooks/test.yml
@@ -1,0 +1,11 @@
+---
+- name: Stress test play
+  hosts: all
+
+  vars:
+    zuul_work_dir: "{{ zuul.project.src_dir }}"
+
+  roles:
+    - role: tox
+      vars:
+        tox_extra_args: -- --cloud openstack --image cirros --debug --no-wait


### PR DESCRIPTION
This adds a run to zuul which runs the stress test in a devstack environment.

Note: Nova fake virt driver is used


The number of lines changed by this PR does not nearly reflect how long this took to get working :upside_down_face: 
