### PR TITLE
Fix black 26.3.1 formatting

### DIFF
--- a/test/unit/test_burnin.py
+++ b/test/unit/test_burnin.py
@@ -8,7 +8,6 @@ from typer.testing import CliRunner
 
 from openstack_simple_stress.main import run
 
-
 app = typer.Typer()
 app.command()(run)
 

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -9,7 +9,6 @@ from openstack_simple_stress.main import (
     run,
 )
 
-
 app = typer.Typer()
 app.command()(run)
 

--- a/test/unit/test_profile.py
+++ b/test/unit/test_profile.py
@@ -12,7 +12,6 @@ from openstack_simple_stress.main import (
     VALID_PROFILE_KEYS,
 )
 
-
 app = typer.Typer()
 app.command()(run)
 


### PR DESCRIPTION
## Summary
- Reformat code to comply with black 26.3.1 stable style (updated in osism/zuul-jobs#180)

## Test plan
- [ ] python-black Zuul job passes